### PR TITLE
Remove secrets.ts from .gitignore and add configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ node_modules/
 
 # Environment and secrets
 .env
-config/secrets.ts
 
 # Logs
 *.log

--- a/config/secrets.ts
+++ b/config/secrets.ts
@@ -1,0 +1,45 @@
+/**
+ * Configuration and secrets for the Demo Web Shop automation
+ */
+
+// Types for our configuration
+interface User {
+  email: string;
+  password: string;
+}
+
+interface Users {
+  admin: User;
+  customer: User;
+}
+
+interface Config {
+  baseUrl: string;
+  users: Users;
+  timeouts: {
+    defaultTimeout: number;
+    navigationTimeout: number;
+  };
+}
+
+// Configuration object
+export const secrets: Config = {
+  baseUrl: 'https://demowebshop.tricentis.com/',
+  users: {
+    admin: {
+      email: 'caspi45@gmail.com',
+      password: 'QS!X5GB6KSpzZn'
+    },
+    customer: {
+      email: 'customer@example.com',
+      password: 'customer123'
+    }
+  },
+  timeouts: {
+    defaultTimeout: 30000, // 30 seconds
+    navigationTimeout: 60000 // 60 seconds
+  }
+};
+
+// Export types for use in other files
+export type { Config, User, Users }; 


### PR DESCRIPTION
Expose the `secrets.ts` file for configuration purposes by removing it from `.gitignore` and implementing the necessary structure for user credentials and timeouts.